### PR TITLE
Support customizing `map` name

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ If you prefer to run the binary directly you have the following options:
 Usage of /tmp/go-build2340306719/b001/exe/osm-tileserver:
   -data string
         Path to directory containing tiles (default "./data")
+  -map string
+        Name of map. This value is also used to determine the metatile subdirectory (default "ajt")
   -port string
         Listening port (default ":8080")
   -renderd-timeout int
@@ -58,7 +60,7 @@ Usage of /tmp/go-build2340306719/b001/exe/osm-tileserver:
 2. Follow the [breadcrumbs](https://github.com/Overv/openstreetmap-tile-server/issues/15) about how to pregenerate tiles for the desired area and zoom-level.
     1. Get a shell in the container: `docker exec -it $CONTAINER_NAME bash`
     2. Download a script that makes it easier to specify GPS coordinates: `curl -o render_list_geo.pl https://raw.githubusercontent.com/alx77/render_list_geo.pl/master/render_list_geo.pl`
-    3. Pregenerate the tiles to your liking: `perl ./render_list_geo.pl -m ajt  -n 3 -z 6 -Z 16 -x 2.5 -X 6.5 -y 49.4 -Y 51.6`
+    3. Pregenerate the tiles to your liking: `perl ./render_list_geo.pl -m ajt -n 3 -z 6 -Z 16 -x 2.5 -X 6.5 -y 49.4 -Y 51.6`
 3. Cheers, you now have tiles in the `$YOUR_TILE_FOLDER`.
 
 ## Performance
@@ -102,5 +104,5 @@ Percentage of the requests served within a certain time (ms)
  100%      9 (longest request)
 ```
 
-This benchmark doesn't access the disk, as the tile has obviously been cached in memory. 
+This benchmark doesn't access the disk, as the tile has obviously been cached in memory.
 Anyways it should give you an indication of whether this is fast enough for your use-case.

--- a/renderer.go
+++ b/renderer.go
@@ -22,7 +22,7 @@ type Request struct {
 	Map         [44]byte
 }
 
-func requestRender(x, y, z uint32, renderd_sock_path string, renderd_timeout time.Duration) error {
+func requestRender(x, y, z uint32, map_name, renderd_sock_path string, renderd_timeout time.Duration) error {
 	c, err := net.Dial("unix", renderd_sock_path)
 	if err != nil {
 		return err
@@ -38,7 +38,7 @@ func requestRender(x, y, z uint32, renderd_sock_path string, renderd_timeout tim
 		Y:           y,
 		Z:           z,
 	}
-	copy(request.Map[:], []byte("ajt"))
+	copy(request.Map[:], []byte(map_name))
 	if err := binary.Write(c, binary.LittleEndian, request); err != nil {
 		return err
 	}


### PR DESCRIPTION
This value was hard-coded, which makes supporting existing `renderd` deployments not possible (at least not without modifying the configuration).

* The `map/xmlconfig` name value corresponds to the [`section name`](https://github.com/openstreetmap/mod_tile/blob/42e4f0d283ba31c9e36077d64e57c9ab66f95ae9/etc/renderd/renderd.conf.examples#L35) specified in `renderd.conf`.
* It is also used in [`meta-tile file path generation`](https://github.com/openstreetmap/mod_tile/blob/42e4f0d283ba31c9e36077d64e57c9ab66f95ae9/src/store_file_utils.c#L202).