### PR TITLE
Upgrade GitHub Actions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   test:
-    container: golang:1.17-alpine
+    container: golang:1.20-alpine
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,14 +1,15 @@
+---
 name: Build and test image
 
 on:
   push:
     branches:
-    - master
+      - master
     tags:
-    - 'v*'
+      - 'v*'
   pull_request:
     branches:
-    - master
+      - master
 
 # cancel outdated jobs for the same reference
 concurrency:
@@ -16,62 +17,62 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE : ${{ github.repository_owner }}/go_tile
-  TAG   : ${{ github.sha }}
+  IMAGE: ${{ github.repository_owner }}/go_tile
+  TAG: ${{ github.sha }}
 
 jobs:
-
   test:
     container: golang:1.17-alpine
     runs-on: ubuntu-latest
     steps:
-    -
-      name: Checkout
-      uses: actions/checkout@v3
-    - run: CGO_ENABLED=0 go test
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run tests
+        run: CGO_ENABLED=0 go test
+
   deploy:
     runs-on: ubuntu-latest
     needs:
-    - test
+      - test
     if: ${{ github.event_name != 'pull_request' }}
     steps:
-    -
-      name: Checkout
-      uses: actions/checkout@v3
-    -
-      name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          ghcr.io/${{ env.IMAGE }}
-        tags: |
-          type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}
-    -
-      name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    -
-      name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    -
-      name: Login to GHCR
-      uses: docker/login-action@v1
-      with:
-        registry : ghcr.io
-        username : ${{ github.repository_owner }}
-        password : ${{ secrets.GITHUB_TOKEN }}
-    -
-      name: Build and push
-      uses: docker/build-push-action@v2
-      with:
-        pull       : true
-        push       : true
-        context    : .
-        file       : ./Dockerfile
-        tags       : ${{ steps.meta.outputs.tags }}
-        labels     : ${{ steps.meta.outputs.labels }}
-        cache-from : type=gha,scope=${{ github.workflow }}
-        cache-to   : type=gha,scope=${{ github.workflow }},mode=max
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ env.IMAGE }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          pull: true
+          push: true
+          context: .
+          file: ./Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,scope=${{ github.workflow }},mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as build
+FROM golang:1.20-alpine as build
 WORKDIR /build
 ADD . .
 RUN CGO_ENABLED=0 go build -o server .


### PR DESCRIPTION
### In order to resolve the following deprecation warnings:
* `Node.js 12` actions are deprecated.
* The `save-state` command is deprecated and will be disabled soon.
* The `set-output` command is deprecated and will be disabled soon.

### Also:
* Upgraded/synchronized `golang` base images from `1.17/1.19` to `1.20`
* Resolved various `yamllint` issues in `.github/workflows/build-and-test.yaml`