### PR TITLE
Dockerfile, Makefile & Testing updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,9 @@
 *
+!docker/go_tile-entrypoint.sh
+!docker/go_tile-healthcheck.sh
 !go.mod
 !go.sum
+!go_tile
 !main.go
-!main_test.go
 !renderer.go
 !static

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -22,14 +22,64 @@ env:
 
 jobs:
   test:
-    container: golang:1.20-alpine
-    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install coreutils (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install coreutils
+
       - name: Run tests
-        run: CGO_ENABLED=0 go test
+        run: make test
+
+      - name: Generate certificate
+        env:
+          SUBJ: ${{ (matrix.os == 'windows-latest') && '//C=US\ST=None\L=None\O=None\CN=localhost' || '/C=US/ST=None/L=None/O=None/CN=localhost' }}
+        run: |
+          openssl req \
+              -new \
+              -newkey rsa:4096 \
+              -days 365 \
+              -nodes \
+              -x509 \
+              -subj "${SUBJ}" \
+              -keyout localhost.key \
+              -out localhost.cert
+        
+      - name: Create metatile directory
+        run: |
+          mkdir -p data/ajt/0/0/0/0/0
+          ln -s ../../../../../../../mock_data/0.meta data/ajt/0/0/0/0/0/0.meta
+
+      - name: Build & run server
+        run: |
+          make build
+          ./go_tile -tls_cert_path localhost.cert -tls_key_path localhost.key &
+
+      - name: Fetch & check tile from server
+        env:
+          HTTP_URL: http://localhost:8080/tile/0/0/0.png
+          HTTPS_URL: https://localhost:8443/tile/0/0/0.png
+          SHA256SUM: d038526e9db340fca762fe2f7e04a368583d9150a7d59ed8d27e40e4e3e00719
+        run: |
+          curl --silent ${HTTP_URL} > tile_http.png
+          curl --insecure --silent ${HTTPS_URL} > tile_https.png
+          echo "${SHA256SUM}  tile_http.png" | sha256sum --check --status && \
+            echo "HTTP SHA256SUM Matching!"
+          echo "${SHA256SUM}  tile_https.png" | sha256sum --check --status && \
+            echo "HTTPS SHA256SUM Matching!"
 
   deploy:
     runs-on: ubuntu-latest
@@ -71,7 +121,7 @@ jobs:
           pull: true
           push: true
           context: .
-          file: ./Dockerfile
+          file: docker/Dockerfile.go_tile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ github.workflow }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
-osm-tileserver
+data
+go_tile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM golang:1.20-alpine as build
-WORKDIR /build
-ADD . .
-RUN CGO_ENABLED=0 go build -o server .
-
-FROM busybox
-COPY --from=build /build/server /bin/go_tile
-ADD ./static /usr/share/go_tile/static
-ENTRYPOINT ["/bin/go_tile", "--static", "/usr/share/go_tile/static"]

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
+CGO_ENABLED ?= 0
 
+build:
+	CGO_ENABLED=$(CGO_ENABLED) go build .
 
-build: osm-tileserver
-	go build .
+clean:
+	CGO_ENABLED=$(CGO_ENABLED) go clean .
 
-# docker run -p 8080:8080 -p 8081:80 -v osm-data:/data/database/ --name osm-test -d overv/openstreetmap-tile-server run
-test: build
-	docker cp ./osm-tileserver osm-test:/bin/osm-tileserver
-	docker cp ./static/ osm-test:/static
-	docker exec -it osm-test /bin/osm-tileserver -static /static -data /var/lib/mod_tile/ajt
+run:
+	CGO_ENABLED=$(CGO_ENABLED) go run .
+
+test:
+	CGO_ENABLED=$(CGO_ENABLED) go test .
+
+.PHONY: \
+	build \
+	clean \
+	run \
+	test

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Currently supported features:
 docker run --rm -it -v $YOUR_TILE_FOLDER:/data -p 8080:8080 ghcr.io/nielsole/go_tile:latest
 ```
 
-Now you can view your map at <http://localhost:8080/>. Tiles are served at <http://localhost:8080/>
+Now you can view your map at <http://localhost:8080/>. Tiles are served at <http://localhost:8080/tile/{z}/{x}/{y}.png>
 
 ### With Docker Compose
 
@@ -40,7 +40,7 @@ This will take some time to download and import all of the data files. Currently
 COMPOSE_FILE=docker/docker-compose.yml docker compose up --build
 ```
 
-Now you can view your map at <http://localhost:8080/>. Tiles are served at <http://localhost:8080/>
+Now you can view your map at <http://localhost:8080/>. Tiles are served at <http://localhost:8080/tile/{z}/{x}/{y}.png>
 
 ### Building from source
 
@@ -55,7 +55,7 @@ go build .
 If you prefer to run the binary directly you have the following options:
 
 ```
-Usage of ./osm-tileserver:
+Usage of ./go_tile:
   -data string
         Path to directory containing tiles (default "./data")
   -map string

--- a/docker/Dockerfile.go_tile
+++ b/docker/Dockerfile.go_tile
@@ -1,0 +1,16 @@
+FROM golang:1.20-alpine as build
+WORKDIR /build
+COPY . .
+RUN CGO_ENABLED=0 go build .
+
+FROM busybox
+COPY --from=build /build/docker/go_tile-entrypoint.sh /docker-entrypoint.sh
+COPY --from=build /build/docker/go_tile-healthcheck.sh /docker-healthcheck.sh
+COPY --from=build /build/go_tile /bin/go_tile
+COPY --from=build /build/static /usr/share/go_tile/static
+
+RUN adduser -D -H -s /bin/nologin go_tile
+
+USER go_tile
+ENTRYPOINT /docker-entrypoint.sh
+HEALTHCHECK CMD /docker-healthcheck.sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,20 +1,23 @@
 ---
+version: "3.8"
+
 services:
   go_tile:
-    build: ..
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.go_tile
     depends_on:
       renderd:
         condition: service_healthy
-    entrypoint: /docker-entrypoint.sh
-    healthcheck:
-      test: ["CMD", "/docker-healthcheck.sh"]
-      start_period: 1m
+    environment:
+      MAP_NAME: default
+      METATILE_DIR: /data/tiles
+      RENDERD_SOCKET: renderd:7654
     ports:
       - 8080:8080
     volumes:
-      - ./go_tile-entrypoint.sh:/docker-entrypoint.sh:ro
-      - ./go_tile-healthcheck.sh:/docker-healthcheck.sh:ro
       - osm-tiles:/data/tiles:ro
+
   renderd:
     entrypoint: /docker-entrypoint.sh
     environment:

--- a/docker/go_tile-entrypoint.sh
+++ b/docker/go_tile-entrypoint.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env sh
 set -eux
 
-go_tile \
-  --data /data/tiles \
-  --map default \
-  --socket renderd:7654 \
-  --static /usr/share/go_tile/static
+OPTIONS="-static ${STATIC_DIR:-/usr/share/go_tile/static}"
+
+if [ -n "${MAP_NAME:-}" ]; then
+  OPTIONS="${OPTIONS:-} -map ${MAP_NAME}"
+fi
+
+if [ -n "${METATILE_DIR:-}" ]; then
+  OPTIONS="${OPTIONS:-} -data ${METATILE_DIR}"
+fi
+
+if [ -n "${RENDERD_SOCKET:-}" ]; then
+  OPTIONS="${OPTIONS:-} -socket ${RENDERD_SOCKET}"
+fi
+
+go_tile ${OPTIONS}

--- a/docker/go_tile-healthcheck.sh
+++ b/docker/go_tile-healthcheck.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
-set -eux
+set -eu
 
 pgrep go_tile

--- a/docker/renderd-healthcheck.sh
+++ b/docker/renderd-healthcheck.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
-set -eux
+set -eu
 
 pgrep renderd

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/nielsole/osm-tileserver
+module github.com/nielsole/go_tile
 
 go 1.20


### PR DESCRIPTION
* Renamed module name (in `go.mod`) from `osm-tileserver` to `go_tile`
  * In order to match the current name of this `repository`
* Added `data` directory to `.gitignore`

### Docker:
* Moved `Dockerfile` into `docker` directory
* Embedded `entrypoint` & `healthcheck` scripts into `go_tile` image
  * With option configurability via environment variable for:
    * `-map` (`MAP_NAME`)
    * `-data` (`METATILE_DIR`)
    * `-socket` (`RENDERD_SOCKET`)
    * `-static` (`STATIC_DIR`)
* Removed `main_test.go` from `go_tile` image
* No longer run as `root` user
### Makefile:
* Cleaned up `Makefile` a bit
  * Added `clean` & `run` targets
### Testing:
* Also run `test` job on `macOS` & `Windows`
* Added external test which downloads & checks the `0/0/0` tile
  * Using both HTTP & HTTPS
