### PR TITLE
Adding Logging facilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 data
 go_tile
+osm-tileserver

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ If you prefer to run the binary directly you have the following options:
 Usage of ./go_tile:
   -data string
         Path to directory containing tiles (default "./data")
+  -log-level string
+        log level (info,error). (default "info")
   -map string
         Name of map. This value is also used to determine the metatile subdirectory (default "ajt")
   -port string
@@ -65,7 +67,7 @@ Usage of ./go_tile:
   -renderd-timeout int
         time in seconds to wait for renderd before returning an error to the client. Set negative to disable (default 60)
   -socket string
-        Unix domain socket path or hostname:port for contacting renderd. Set to '' to disable rendering (default "")
+        Unix domain socket path or hostname:port for contacting renderd. Set to '' to disable rendering
   -static string
         Path to static file directory (default "./static/")
   -tile_expiration duration

--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ Currently supported features:
 
 ## Usage
 
-### With a renderd backend
-
-* Currently there are no binaries included here automatically (I might have manually included them for some releases), so you will need to build from source
-* a slippymap with leaflet is provided in the ./static/ folder
-* You need to have a working renderd setup
-
 ### With Docker and pregenerated static tiles
 
 ```shell
@@ -32,7 +26,7 @@ docker run --rm -it -v $YOUR_TILE_FOLDER:/data -p 8080:8080 ghcr.io/nielsole/go_
 
 Now you can view your map at <http://localhost:8080/>. Tiles are served at <http://localhost:8080/tile/{z}/{x}/{y}.png>
 
-### With Docker Compose
+### With Docker Compose and renderd
 
 This will take some time to download and import all of the data files. Currently it is configured to populate the map with `Hamburg, Germany`, but the data files can be changed by modifying `DOWNLOAD_PBF` & `DOWNLOAD_POLY` in the [`docker/docker-compose.yml`](/docker/docker-compose.yml) file.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Currently supported features:
 
 ## Usage
 
+### With a renderd backend
+
+* Currently there are no binaries included here automatically (I might have manually included them for some releases), so you will need to build from source
+* a slippymap with leaflet is provided in the ./static/ folder
+* You need to have a working renderd setup
+
 ### With Docker and pregenerated static tiles
 
 ```shell
@@ -26,7 +32,7 @@ docker run --rm -it -v $YOUR_TILE_FOLDER:/data -p 8080:8080 ghcr.io/nielsole/go_
 
 Now you can view your map at <http://localhost:8080/>. Tiles are served at <http://localhost:8080/tile/{z}/{x}/{y}.png>
 
-### With Docker Compose and renderd
+### With Docker Compose
 
 This will take some time to download and import all of the data files. Currently it is configured to populate the map with `Hamburg, Germany`, but the data files can be changed by modifying `DOWNLOAD_PBF` & `DOWNLOAD_POLY` in the [`docker/docker-compose.yml`](/docker/docker-compose.yml) file.
 

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+type LogLevel int
+
+const (
+	Debug LogLevel = iota
+	Info
+	Warn
+	Error
+	Critical
+)
+
+type Logger struct {
+	LogLevel LogLevel
+}
+
+func NewLogger() *Logger {
+	return &Logger{LogLevel: Warn}
+}
+
+func (l *Logger) Debug(msg string) {
+	if l.LogLevel <= Debug {
+		now := time.Now().Format(time.RFC3339)
+		fmt.Printf("[%s] [DEBUG] %s\n", now, msg)
+	}
+}
+
+func (l *Logger) Info(msg string) {
+	if l.LogLevel <= Info {
+		now := time.Now().Format(time.RFC3339)
+		fmt.Printf("[%s] [INFO] %s\n", now, msg)
+	}
+}
+
+func (l *Logger) Warn(msg string) {
+	if l.LogLevel <= Warn {
+		now := time.Now().Format(time.RFC3339)
+		fmt.Printf("[%s] [WARN] %s\n", now, msg)
+	}
+}
+
+func (l *Logger) Error(msg string) {
+	if l.LogLevel <= Error {
+		now := time.Now().Format(time.RFC3339)
+		fmt.Printf("[%s] [ERROR] %s\n", now, msg)
+	}
+}
+
+func (l *Logger) Critical(msg string) {
+	if l.LogLevel <= Critical {
+		now := time.Now().Format(time.RFC3339)
+		fmt.Printf("[%s] [CRITICAL] %s\n", now, msg)
+	}
+}


### PR DESCRIPTION
Logs during startup are retained at any loglevel. The goal of this PR is to regulate the log verbosity at runtime, mostly around access logs.