### PR TITLE
Log levels and minor code updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 !go.mod
 !go.sum
 !go_tile
+!logger.go
 !main.go
 !renderer.go
 !static

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       MAP_NAME: default
       METATILE_DIR: /data/tiles
       RENDERD_SOCKET: renderd:7654
+      VERBOSE: true
     ports:
       - 8080:8080
     volumes:

--- a/docker/go_tile-entrypoint.sh
+++ b/docker/go_tile-entrypoint.sh
@@ -15,4 +15,8 @@ if [ -n "${RENDERD_SOCKET:-}" ]; then
   OPTIONS="${OPTIONS:-} -socket ${RENDERD_SOCKET}"
 fi
 
-go_tile -verbose ${OPTIONS}
+if [ "${VERBOSE:-false}" = "true" ]; then
+  OPTIONS="${OPTIONS:-} -verbose"
+fi
+
+go_tile ${OPTIONS}

--- a/docker/go_tile-entrypoint.sh
+++ b/docker/go_tile-entrypoint.sh
@@ -15,4 +15,4 @@ if [ -n "${RENDERD_SOCKET:-}" ]; then
   OPTIONS="${OPTIONS:-} -socket ${RENDERD_SOCKET}"
 fi
 
-go_tile ${OPTIONS}
+go_tile -verbose ${OPTIONS}

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"log"
+)
+
+func logDebugf(format string, v ...interface{}) {
+	log.Printf(logPrefixFormat("DEBUG", format), v...)
+}
+
+func logErrorf(format string, v ...interface{}) {
+	log.Printf(logPrefixFormat("ERROR", format), v...)
+}
+
+func logFatalf(format string, v ...interface{}) {
+	log.Fatalf(logPrefixFormat("FATAL", format), v...)
+}
+
+func logInfof(format string, v ...interface{}) {
+	log.Printf(logPrefixFormat("INFO", format), v...)
+}
+
+func logWarningf(format string, v ...interface{}) {
+	log.Printf(logPrefixFormat("WARNING", format), v...)
+}
+
+func logPrefixFormat(level string, format string) string {
+	return fmt.Sprintf("%-7s | %s", level, format)
+}

--- a/renderer.go
+++ b/renderer.go
@@ -26,9 +26,8 @@ func getSocketConnection(renderd_socket string) (net.Conn, error) {
 	renderd_socket_type, renderd_tcp_addr := getSocketType(renderd_socket)
 	if renderd_socket_type == "tcp" {
 		return net.DialTCP("tcp", nil, renderd_tcp_addr)
-	} else {
-		return net.Dial("unix", renderd_socket)
 	}
+	return net.Dial("unix", renderd_socket)
 }
 
 func requestRender(x, y, z uint32, map_name, renderd_socket string, renderd_timeout time.Duration, priority int) error {


### PR DESCRIPTION
RE: https://github.com/nielsole/go_tile/issues/6#issuecomment-1493401549

Good points, here are some comments:

> * No need for Sprintf
* I also prefer not needing to use `fmt.Sprintf` for every call.
> * Fatal is more in line with existing stdlib than Critical and avoids confusion about whether or not the call will call os.Exit(1).
* I thought I might as well just utilize the existing `log.Fatalf` function (including the `exit`) since it already exists.
> * No need for a struct. Making a struct and then making it a global kind of defeats the point. Might as well be flat function calls. A struct feels a bit more like idiomatic go and direct function calls feel a bit like C, but so what.
* Either way is fine for me, I think there certainly is room for improvement in my `logger.go` implementation.
  * Feel free to give me some feedback.
> * I like your other changes, e.g. renaming from tls to https, cleaning up the mux creation, cleanup of duration flag parsing and they are not trivial to separate
* Thanks, I was trying to understand the flow a bit better and felt like a few variable-renames and such would help.

---

Also, I can clean things up around here:

> * How would one disable verbose in the docker container (except overriding the entrypoint)? Probably just something you left in for testing.
* Sure, I hadn't yet opened a pull request, so it wasn't quite "feature complete". I envision it would be enable-able via an environment variable (defaulting to off) similar to what was done for the other configurable arguments, I.E.:
https://github.com/nielsole/go_tile/blob/a1d869d55fcdfd74018902581f25a7bca6ded620/docker/docker-compose.yml#L12-L15
> * Should we add the timestamp similar to what I did in my PR?
* Yes, I do think having a timestamp is important, in my testing, however, there already is a time and date being output from the [`log` package](https://pkg.go.dev/log#pkg-constants) and I thought that would be sufficient, Let me know if you had something else in mind for the timestamp.
  ```shell
  $ make build && ./go_tile -port 8081
  CGO_ENABLED=0 go build .
  2023/04/02 15:19:00 INFO    | Rendering is disabled
  2023/04/02 15:19:00 INFO    | TLS is disabled
  2023/04/02 15:19:00 INFO    | Started HTTP listener on 0.0.0.0:8081
  ```